### PR TITLE
fix missing virtual function '= 0' in class Residual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,5 +28,5 @@ endif()
 
 # The cmake build system isn't used for debugging,
 # so default to an optimized build.
-add_compile_options(-O3 -g0 -std=c++11) 
+#add_compile_options(-O3 -g0 -std=c++11)
 add_subdirectory(fbstab)

--- a/fbstab/components/abstract_components.h
+++ b/fbstab/components/abstract_components.h
@@ -204,7 +204,7 @@ class Residual {
    *
    * @param[in] x Evaluation point.
    */
-  virtual void NaturalResidual(const Variable& x);
+  virtual void NaturalResidual(const Variable& x) = 0;
 
   /**
    * Computes the natural residual function augmented with
@@ -214,7 +214,7 @@ class Residual {
    *
    * @param[in] x Evaluation point.
    */
-  virtual void PenalizedNaturalResidual(const Variable& x);
+  virtual void PenalizedNaturalResidual(const Variable& x) = 0;
 
   /** @return ||z|| */
   virtual double z_norm() const = 0;


### PR DESCRIPTION
Two pure virtual function declarations are missing "= 0", which could cause "symbol not found" errors in linking stage.